### PR TITLE
Fix: Prevent tab titles from getting stuck in Pick Mode

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -72,6 +72,10 @@
     "close-all-old-tabs": {
       "description": "Close all tabs that haven't been opened after a configurable time",
       "global": true
+    },
+    "clear-pick-mode": {
+      "description": "Clear pick mode and restore tab titles",
+      "global": true
     }
   }
 }


### PR DESCRIPTION
This commit addresses a bug where tab titles could get stuck in "Pick Mode" if the user switched tabs after activating it.

The fix includes:
- Centralizing the pick mode timeout logic in the background script to prevent race conditions and ensure it always fires correctly.
- Injecting the keydown listener into all tabs, but only allowing the active tab to respond to key presses. This ensures that pick mode can be exited regardless of which tab is active.

Additionally, this commit introduces a new command `clear-pick-mode` that allows the user to manually restore tab titles if they ever get stuck.

The title restoration logic has also been improved to correctly handle pinned tabs, ensuring the pin marker is preserved.