### PR TITLE
feat: Change auto-close time to minutes and improve options page styling

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,7 +12,7 @@ function isUrlRestricted(url) {
 
 let reorderDelay = 5000; // Default value in ms, will be updated from storage.
 let autoCloseEnabled = false;
-let autoCloseTime = 1; // Default value in hours
+let autoCloseTime = 60; // Default value in minutes
 let tabLastActivated = {};
 
 // Function to load user settings and listen for changes.
@@ -21,14 +21,14 @@ function initializeSettings() {
     chrome.storage.sync.get({
         delay: 5,
         autoCloseEnabled: false,
-        autoCloseTime: 1
+        autoCloseTime: 60
     }, (items) => {
         reorderDelay = items.delay * 1000;
         autoCloseEnabled = items.autoCloseEnabled;
         autoCloseTime = items.autoCloseTime;
         console.log(`[Settings] Initial auto-reorder delay set to ${reorderDelay}ms.`);
         console.log(`[Settings] Auto-close enabled: ${autoCloseEnabled}.`);
-        console.log(`[Settings] Auto-close time: ${autoCloseTime} hour(s).`);
+        console.log(`[Settings] Auto-close time: ${autoCloseTime} minute(s).`);
     });
 
     // Listen for changes to settings.
@@ -50,7 +50,7 @@ function initializeSettings() {
             }
             if (changes.autoCloseTime) {
                 autoCloseTime = changes.autoCloseTime.newValue;
-                console.log(`[Settings] Auto-close time updated to ${autoCloseTime} hour(s).`);
+                console.log(`[Settings] Auto-close time updated to ${autoCloseTime} minute(s).`);
             }
         }
     });
@@ -531,7 +531,7 @@ async function closeOldTabs() {
 
     const tabs = await chrome.tabs.query({});
     const now = Date.now();
-    const autoCloseTimeMs = autoCloseTime * 60 * 60 * 1000;
+    const autoCloseTimeMs = autoCloseTime * 60 * 1000;
 
     for (const tab of tabs) {
         if (pinnedTabs.includes(tab.id)) {

--- a/options.html
+++ b/options.html
@@ -4,41 +4,82 @@
     <title>Tbbr Options</title>
     <style>
         body {
-            font-family: sans-serif;
-            padding: 10px;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            background-color: #f0f2f5;
+            color: #333;
+            margin: 0;
+            padding: 20px;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            box-sizing: border-box;
+        }
+        .container {
+            background: #fff;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+            width: 100%;
+            max-width: 500px;
+        }
+        h1 {
+            text-align: center;
+            color: #1a73e8;
+            margin-bottom: 30px;
         }
         .option {
-            margin-bottom: 15px;
+            margin-bottom: 20px;
         }
         label {
             display: block;
-            margin-bottom: 5px;
+            margin-bottom: 8px;
+            font-weight: 500;
+        }
+        input[type="number"], input[type="checkbox"] {
+            margin-right: 8px;
         }
         input[type="number"] {
-            width: 60px;
+            width: 80px;
+            padding: 8px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+        }
+        .auto-close-label {
+            display: flex;
+            align-items: center;
+        }
+        #status {
+            text-align: center;
+            margin-top: 20px;
+            color: #4caf50;
+            font-weight: bold;
+            height: 20px;
         }
     </style>
 </head>
 <body>
-    <h1>Tbbr Settings</h1>
-    <div class="option">
-        <label for="delay">Auto-reorder delay (in seconds):</label>
-        <input type="number" id="delay" min="0">
-    </div>
+    <div class="container">
+        <h1>Tbbr Settings</h1>
+        <div class="option">
+            <label for="delay">Auto-reorder delay (in seconds):</label>
+            <input type="number" id="delay" min="0">
+        </div>
 
-    <div class="option">
-        <label>
-            <input type="checkbox" id="autoCloseEnabled">
-            Automatically close tabs that haven't been opened in a while
-        </label>
-    </div>
+        <div class="option">
+            <label class="auto-close-label">
+                <input type="checkbox" id="autoCloseEnabled">
+                Automatically close tabs that haven't been opened in a while
+            </label>
+        </div>
 
-    <div class="option">
-        <label for="autoCloseTime">Auto-close time (in hours):</label>
-        <input type="number" id="autoCloseTime" min="1" value="1">
-    </div>
+        <div class="option">
+            <label for="autoCloseTime">Auto-close time (in minutes):</label>
+            <input type="number" id="autoCloseTime" min="1" value="60">
+        </div>
 
-    <div id="status"></div>
+        <div id="status"></div>
+    </div>
 
     <script src="options.js"></script>
 </body>

--- a/options.js
+++ b/options.js
@@ -24,7 +24,7 @@ function restore_options() {
   chrome.storage.sync.get({
     delay: 5,
     autoCloseEnabled: false,
-    autoCloseTime: 1
+    autoCloseTime: 60
   }, function(items) {
     document.getElementById('delay').value = items.delay;
     document.getElementById('autoCloseEnabled').checked = items.autoCloseEnabled;


### PR DESCRIPTION
This commit updates the "Auto-close time" setting to be in minutes instead of hours. The default value has been changed from 1 hour to 60 minutes. All related logic and labels have been updated accordingly.

Additionally, the options page has been restyled to be more modern and visually appealing.