### PR TITLE
fix: Prevent script injection into chrome-extension:// pages

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,10 +3,11 @@ const listOfLetters = ['a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l', ';', 'u', 'i
 function isUrlRestricted(url) {
     if (!url) return true;
     // Extensions are not allowed to script pages with chrome://, edge://, or about: schemes,
-    // nor can they script the Chrome Web Store.
+    // their own internal pages, or the Chrome Web Store.
     return url.startsWith('chrome://') ||
            url.startsWith('edge://') ||
            url.startsWith('about:') ||
+           url.startsWith('chrome-extension://') ||
            url.startsWith('https://chrome.google.com/webstore/');
 }
 


### PR DESCRIPTION
This commit fixes a critical bug where the 'pick mode' feature would attempt to inject content scripts into the extension's own internal pages (e.g., options.html) if they were open in a tab.

This was causing the extension to crash with a 'Cannot access contents of url' error, followed by 'Extension context invalidated' errors from other parts of the extension.

The fix is to update the `isUrlRestricted` utility function to also check for and prevent injection into URLs starting with `chrome-extension://`.