### PR TITLE
fix: Correct syntax error in command listener

### DIFF
--- a/background.js
+++ b/background.js
@@ -419,6 +419,7 @@ chrome.commands.onCommand.addListener((command) => {
       );
     });
   });
+  }
 });
 
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {


### PR DESCRIPTION
Fixes a syntax error in background.js where the chrome.commands.onCommand listener was prematurely closed inside an if block. This caused the extension to fail to load.