### PR TITLE
fix: Handle context invalidated error in content script

### DIFF
--- a/mouse_tracker.js
+++ b/mouse_tracker.js
@@ -1,43 +1,60 @@
 // Use a flag to track mouse state to avoid sending redundant messages.
 let isInside = false;
 
-// Function to handle sending mouse enter messages.
+// Define the event handler functions so they can be referenced for removal.
 function handleMouseEnter() {
     if (!isInside) {
         isInside = true;
-        chrome.runtime.sendMessage({ type: "mouse_enter" }).catch(err => {
-            // Suppress "Receiving end does not exist" errors, which can happen
-            // during extension reloads or page navigation.
-            if (!err.message.includes('Receiving end does not exist')) {
-                console.error("Error sending mouse_enter message:", err);
-            }
-        });
+        sendMessage({ type: "mouse_enter" });
     }
 }
 
-// Function to handle sending mouse leave messages.
-function handleMouseLeave() {
+function handleMouseLeave(e) {
+    // When the mouse leaves the viewport entirely, relatedTarget will be null.
+    // We also check for the blur event case where 'e' might be undefined.
+    if (e.type === 'mouseout' && e.relatedTarget !== null) {
+        return; // Not a true leave event, just moving between elements.
+    }
+
     if (isInside) {
         isInside = false;
-        chrome.runtime.sendMessage({ type: "mouse_leave" }).catch(err => {
-            if (!err.message.includes('Receiving end does not exist')) {
-                console.error("Error sending mouse_leave message:", err);
-            }
-        });
+        sendMessage({ type: "mouse_leave" });
     }
 }
 
-// Listen for mouseover and mouseout on the window. This is more reliable
-// for catching events on the entire viewport, including iframes.
-window.addEventListener('mouseover', handleMouseEnter);
-window.addEventListener('mouseout', (e) => {
-    // When the mouse leaves the viewport entirely, relatedTarget will be null.
-    if (e.relatedTarget === null) {
-        handleMouseLeave();
+// A wrapper for sendMessage to handle errors gracefully.
+function sendMessage(message) {
+    try {
+        // The promise-based sendMessage can still throw a synchronous error
+        // if the extension context is invalidated.
+        chrome.runtime.sendMessage(message).catch(err => {
+            // This catch block handles asynchronous errors, like the receiving
+            // end not existing. We can safely ignore this error as it's
+            // expected during extension reloads.
+        });
+    } catch (e) {
+        // This catch block handles synchronous errors, primarily the
+        // "Extension context invalidated" error.
+        if (e.message.includes('Extension context invalidated')) {
+            // If the context is gone, we can't send messages anymore.
+            // The best course of action is to clean up our listeners to
+            // prevent this error from firing again on this page.
+            console.log("Tbbr: Extension context invalidated. Removing mouse listeners for this page.");
+            cleanupEventListeners();
+        } else {
+            // For any other unexpected synchronous errors, log them.
+            console.error("Tbbr: Unexpected error sending message:", e);
+        }
     }
-});
+}
 
-// Also, listen for the blur event on the window. This can happen if the user
-// switches to another application or clicks into an iframe, which is a good
-// time to consider the mouse as "left".
+function cleanupEventListeners() {
+    window.removeEventListener('mouseover', handleMouseEnter);
+    window.removeEventListener('mouseout', handleMouseLeave);
+    window.removeEventListener('blur', handleMouseLeave);
+}
+
+// Add the event listeners.
+window.addEventListener('mouseover', handleMouseEnter);
+window.addEventListener('mouseout', handleMouseLeave);
 window.addEventListener('blur', handleMouseLeave);


### PR DESCRIPTION
Improves the robustness of the mouse_tracker.js content script by adding error handling for "Extension context invalidated" errors.

When this error occurs (e.g., after an extension reload), the script will now catch the error and remove its event listeners to prevent further errors on the page.