### PR TITLE
feat: Add reopen tab command and enhance pin detection

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,8 @@
     "commands",
     "storage",
     "alarms",
-    "notifications"
+    "notifications",
+    "sessions"
   ],
   "host_permissions": [
     "*://*/*",
@@ -105,6 +106,10 @@
     },
     "go-to-last-tab-in-list": {
         "description": "Go to the last tab in the tab list",
+        "global": true
+    },
+    "reopen-last-closed-tab": {
+        "description": "Reopen the last closed tab",
         "global": true
     }
   }


### PR DESCRIPTION
- Adds a new command `reopen-last-closed-tab` to reopen the last closed tab using the `chrome.sessions` API.
- Adds the `sessions` permission to `manifest.json` to support this functionality.
- Enhances tab pinning logic by creating a new `isTabPinned` helper function.
- This function treats a tab as pinned if it's natively pinned, in the extension's manual pin list, or if its title starts with a "📌" emoji.
- Integrates this new logic into the auto-reorder and auto-close features to prevent them from affecting pinned tabs.