### PR TITLE
feat: Add move-tab-to-end command

### DIFF
--- a/background.js
+++ b/background.js
@@ -313,6 +313,9 @@ function handleCommand(command) {
         case 'move-tab-right':
             moveTabRight();
             break;
+        case 'move-tab-to-end':
+            moveTabToEnd();
+            break;
         default:
             if (command.startsWith('focus-tab-')) {
                 focusTabByIndex(command);
@@ -777,6 +780,17 @@ function moveTabRight() {
                 if (currentTab.index < allTabs.length - 1) {
                     chrome.tabs.move(currentTab.id, { index: currentTab.index + 1 });
                 }
+            });
+        }
+    });
+}
+
+function moveTabToEnd() {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+        if (tabs.length > 0) {
+            const currentTab = tabs[0];
+            chrome.tabs.query({ currentWindow: true }, (allTabs) => {
+                chrome.tabs.move(currentTab.id, { index: allTabs.length - 1 });
             });
         }
     });

--- a/manifest.json
+++ b/manifest.json
@@ -139,6 +139,10 @@
     "move-tab-right": {
       "description": "Move the current tab to the right",
       "global": true
+    },
+    "move-tab-to-end": {
+      "description": "Move the current tab to the end",
+      "global": true
     }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,7 @@ To prevent a tab from being automatically reordered or closed by bulk actions, y
 *   **`move-to-first`**: Move current tab to the front. (Suggested: `Alt+g`)
 *   **`move-tab-left`**: Move the current tab one position to the left.
 *   **`move-tab-right`**: Move the current tab one position to the right.
+*   **`move-tab-to-end`**: Move the current tab to the last position.
 *   **`reopen-last-closed-tab`**: Restores the most recently closed tab or window.
 *   **`close-all-preceding-tabs`**: Closes all tabs to the left of the current tab.
 *   **`close-all-following-tabs`**: Closes all tabs to the right of the current tab.


### PR DESCRIPTION
Adds a new command 'move-tab-to-end' that moves the currently active tab to the last position in the tab list.

The implementation involves:
- Adding the command to `manifest.json`.
- Creating a `moveTabToEnd` function in `background.js`.
- Handling the command in the `handleCommand` switch statement.
- Documenting the new command in `readme.md`.