### PR TITLE
Fix multiple critical bugs and improve quality of life

### DIFF
--- a/options.html
+++ b/options.html
@@ -231,9 +231,9 @@
                 <legend>Auto-Close Whitelist</legend>
                 <div class="option-group">
                     <div class="option">
-                        <label for="autoCloseWhitelist">Domains to never auto-close</label>
+                        <label for="autoCloseWhitelist">Domains or paths to never auto-close</label>
                         <textarea id="autoCloseWhitelist" rows="5"></textarea>
-                        <p class="description">Enter one domain per line (e.g., docs.google.com). Tabs with these domains will never be auto-closed, regardless of unsaved changes checks.</p>
+                        <p class="description">Enter one domain (e.g., `docs.google.com`) or full file path (e.g., `file:///path/to/your/file.html`) per line. Tabs with these domains or paths will never be auto-closed.</p>
                     </div>
                 </div>
             </fieldset>


### PR DESCRIPTION
This commit addresses a comprehensive list of critical bugs and logical flaws to improve the extension's stability, correctness, and user experience. It also incorporates feedback to refine the initial fixes.

The following issues have been resolved:

1.  **Options Not Saved:** The 'Tab activation delay' and 'Warning indicator time' settings are now correctly saved and restored from storage.

2.  **Title State Corruption:** Implemented a centralized title manager (`tabOriginalTitles` map) to prevent features like Countdown Timers and Pick Mode from corrupting tab titles. The title cleaning heuristic has also been made more specific to avoid mangling legitimate titles (e.g., `[JIRA-123]...`).

3.  **Auto-Close Race Condition:** Fixed a race condition where the active tab could be closed. The logic now performs a fresh check to ensure a tab is not active immediately before removal.

4.  **Pinning State Desynchronization:** The `toggle-pin` command now correctly uses the native `chrome.tabs.update` API. An event listener for `chrome.tabs.onUpdated` ensures the extension's internal state and UI (the '📌' icon) always stay in sync with the browser's native pinning.

5.  **Window-Insensitive Auto-Close:** The auto-close feature is now scoped to the current window, preventing the unexpected closure of tabs in background windows.

6.  **Pick Mode on Restricted Pages:** Pick Mode now filters out restricted URLs (e.g., `chrome://` pages) before injecting scripts and assigning letters, ensuring correct tab indexing and preventing silent failures.

7.  **Unreliable Unsaved Data Check:** Added a user-configurable domain/path whitelist in the options. This allows users to prevent auto-closing on critical sites. The feature now supports both domains (e.g., `docs.google.com`) and local file paths (e.g., `file:///path/to/file.html`).

8.  **Vague Notifications:** The auto-close notification has been changed from a basic message to a list-style notification that displays the titles of the tabs that were closed, providing more specific feedback to the user.