### PR TITLE
Fix TypeError in notifications.create call

### DIFF
--- a/background.js
+++ b/background.js
@@ -549,7 +549,7 @@ async function closeOldTabs() {
     const closedTabs = results.filter(Boolean);
 
     if (closedTabs.length > 0) {
-        const notificationItems = closedTabs.map(tab => ({ title: tab.title }));
+        const notificationItems = closedTabs.map(tab => ({ title: tab.title, message: tab.url || 'No URL available' }));
         const title = `Closed ${closedTabs.length} old tab(s)`;
 
         chrome.notifications.create({


### PR DESCRIPTION
The `chrome.notifications.create` API call for list notifications was failing with a `TypeError` because the items in the `items` array were missing the required `message` property.

This change modifies the `closeOldTabs` function in `background.js` to include the `message` property in each item of the `notificationItems` array. The tab's URL is used as the message, providing more context to the user about the closed tabs. A fallback string is included in case the URL is not available.