### PR TITLE
Fix: Resolve race condition in close-pick command

### DIFF
--- a/background.js
+++ b/background.js
@@ -651,22 +651,28 @@ function handlePickModeKeyPress(key, shiftKey) {
 
     const letterIndex = listOfLetters.indexOf(key);
     if (letterIndex > -1) {
+        // Capture the mode at the time of the key press.
+        const shouldClose = isClosePickMode;
+
         chrome.tabs.query({ currentWindow: true }, (tabs) => {
             const injectableTabs = tabs.filter(tab => !isUrlRestricted(tab.url));
             if (letterIndex < injectableTabs.length) {
                 const targetTab = injectableTabs[letterIndex];
                 if (targetTab) {
                     const targetTabId = targetTab.id;
-                    if (shiftKey || isClosePickMode) {
+                    // Use the captured mode, not the global one which may have been reset.
+                    if (shiftKey || shouldClose) {
                         chrome.tabs.remove(targetTabId);
                     } else {
                         chrome.tabs.update(targetTabId, { active: true, highlighted: true });
                     }
                 }
             }
+            endPickMode();
         });
+    } else {
+        endPickMode();
     }
-    endPickMode();
 }
 
 // Content script for polite listener (active tab)


### PR DESCRIPTION
The "Select a tab to close by letter" command was not working correctly due to a race condition. The `isClosePickMode` flag was being reset before the asynchronous `chrome.tabs.query` callback could execute.

This fix resolves the issue by capturing the value of `isClosePickMode` in a local variable at the time of the key press. This ensures that the correct action (closing or switching the tab) is performed within the callback, regardless of when `endPickMode()` is called.